### PR TITLE
add getTotalItems() and fix limit method so PaginatedList works

### DIFF
--- a/src/SilverStripe/Elastica/ResultList.php
+++ b/src/SilverStripe/Elastica/ResultList.php
@@ -12,6 +12,7 @@ class ResultList extends \ViewableData implements \SS_Limitable, \SS_List {
 
 	private $index;
 	private $query;
+	private $search;
 
 	public function __construct(Index $index, Query $query) {
 		$this->index = $index;
@@ -35,12 +36,29 @@ class ResultList extends \ViewableData implements \SS_Limitable, \SS_List {
 	public function getQuery() {
 		return $this->query;
 	}
+	
+	/**
+	 * @return \Elastica\Search
+	 */
+	public function getSearch() {
+		if(!$this->search) {
+			$this->search = $this->index->search($this->query);
+		}
+		return $this->search;
+	}
 
 	/**
 	 * @return array
 	 */
 	public function getResults() {
-		return $this->index->search($this->query)->getResults();
+		return $this->getSearch()->getResults();
+	}
+	
+	/**
+	 * @return int
+	 */
+	public function getTotalItems() {
+		return $this->getSearch()->getTotalHits();
 	}
 
 	public function getIterator() {
@@ -48,12 +66,9 @@ class ResultList extends \ViewableData implements \SS_Limitable, \SS_List {
 	}
 
 	public function limit($limit, $offset = 0) {
-		$list = clone $this;
-
-		$list->getQuery()->setLimit($limit);
-		$list->getQuery()->setFrom($offset);
-
-		return $list;
+		$this->query->setLimit($limit);
+		$this->query->setFrom($offset);
+		return $this;
 	}
 
 	/**


### PR DESCRIPTION
Currently we can't pass Totalitems to PaginatedList() from Elastica\ResultSet->getTotalHits();

Example:
$result = ResultList::create($index, $query);
$result->limit(10,(int)$this->request->getVar('start'));  
$list = new PaginatedList($result);
$list->setTotalItems($result->getTotalItems());
