### PR TITLE
FEATURE: Add multi match search

### DIFF
--- a/src/SilverStripe/Elastica/ElasticaService.php
+++ b/src/SilverStripe/Elastica/ElasticaService.php
@@ -4,6 +4,7 @@ namespace SilverStripe\Elastica;
 
 use Elastica\Client;
 use Elastica\Query;
+use Elastica\Query\MultiMatch;
 
 /**
  * A service used to interact with elastic search.
@@ -50,10 +51,20 @@ class ElasticaService {
 	 * Performs a search query and returns a result list.
 	 *
 	 * @param \Elastica\Query|string|array $query
+	 * @param array $fields An optional list of fields to search
 	 * @return ResultList
 	 */
-	public function search($query) {
-		return new ResultList($this->getIndex(), Query::create($query));
+	public function search($query, $fields = array ()) {
+		if(!empty($fields)) {
+			$q = new MultiMatch();
+			$q->setQuery($query);
+			$q->setFields($fields);
+		}
+		else {
+			$q = Query::create($query);
+		}
+
+		return new ResultList($this->getIndex(), $q);
 	}
 
 	/**


### PR DESCRIPTION
This allows searching across multiple fields, and boosting them, if required.

```php
$elastic = Injector::inst()->get('SilverStripe\Elastica\ElasticaService');
$results = $elastic->search($query, array('Title^3', 'Content'));
```

I'm 90% sure this is not going to be your preferred solution, but I figured best to get the dialogue started.

Another approach would be to add a new method, `searchMulti` instead of the polymorphic approach.