### PR TITLE
Allow overriding getElasticaFields in owner class

### DIFF
--- a/src/SilverStripe/Elastica/Searchable.php
+++ b/src/SilverStripe/Elastica/Searchable.php
@@ -84,7 +84,7 @@ class Searchable extends \DataExtension {
 	public function getElasticaDocument() {
 		$fields = array();
 
-		foreach ($this->getElasticaFields() as $field => $config) {
+		foreach ($this->owner->getElasticaFields() as $field => $config) {
 			$fields[$field] = $this->owner->$field;
 		}
 


### PR DESCRIPTION
Currently the list of fields used to create the elastica document is generated from the DataObject's searchable fields. This limits the fields to actual database fields and prevents the use of custom getters to provide data to the elastica document.

This was recently an issue for me when I wanted to add the contents of an attached PDF as a string field to the elastica document.

This minor change allows the getElasticaFields() method to be safely overridden in the extended DataObject and thus provide the flexibility to use custom getter fields.