### PR TITLE
Added name to config

### DIFF
--- a/_config/dependencies.yml
+++ b/_config/dependencies.yml
@@ -1,3 +1,6 @@
+---
+name: 'elastica'
+---
 Injector:
   SilverStripe\Elastica\ReindexTask:
     constructor:


### PR DESCRIPTION
This adds a name to the YAML config, so that it can be referenced in "after" hooks, in other YAML config files.